### PR TITLE
:heavy_plus_sign: Add Python 3.8 with Alpine 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-dist: xenial
+dist: bionic
 
 language: python
 
 python:
-  - "3.7"
+  - "3.8"
 
 install:
   - pip install docker pytest
@@ -13,8 +13,10 @@ services:
 
 env:
   - NAME='latest' BUILD_PATH='python3.7' TEST_STR1='Hello world! From Starlette running on Uvicorn with Gunicorn. Using Python 3.7'
+  - NAME='python3.8' BUILD_PATH='python3.7' TEST_STR1='Hello world! From Starlette running on Uvicorn with Gunicorn. Using Python 3.8'
   - NAME='python3.7' BUILD_PATH='python3.7' TEST_STR1='Hello world! From Starlette running on Uvicorn with Gunicorn. Using Python 3.7'
   - NAME='python3.6' BUILD_PATH='python3.6' TEST_STR1='Hello world! From Starlette running on Uvicorn with Gunicorn. Using Python 3.6'
+  - NAME='python3.8-alpine3.10' BUILD_PATH='python3.7-alpine3.8' TEST_STR1='Hello world! From Starlette running on Uvicorn with Gunicorn in Alpine. Using Python 3.8'
   - NAME='python3.7-alpine3.8' BUILD_PATH='python3.7-alpine3.8' TEST_STR1='Hello world! From Starlette running on Uvicorn with Gunicorn in Alpine. Using Python 3.7'
   - NAME='python3.6-alpine3.8' BUILD_PATH='python3.6-alpine3.8' TEST_STR1='Hello world! From Starlette running on Uvicorn with Gunicorn in Alpine. Using Python 3.6'
   

--- a/README.md
+++ b/README.md
@@ -2,16 +2,18 @@
 
 ## Supported tags and respective `Dockerfile` links
 
+* [`python3.8` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/blob/master/python3.8/Dockerfile)
 * [`python3.7`, `latest` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/blob/master/python3.7/Dockerfile)
 * [`python3.6` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/blob/master/python3.6/Dockerfile)
 * [`python3.6-alpine3.8` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/blob/master/python3.6-alpine3.8/Dockerfile)
 * [`python3.7-alpine3.8` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/blob/master/python3.7-alpine3.8/Dockerfile)
+* [`python3.8-alpine3.10` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/blob/master/python3.8-alpine3.10/Dockerfile)
 
 **Note**: Note: There are [tags for each build date](https://hub.docker.com/r/tiangolo/uvicorn-gunicorn-starlette/tags). If you need to "pin" the Docker image version you use, you can select one of those tags. E.g. `tiangolo/uvicorn-gunicorn-starlette:python3.7-2019-10-15`.
 
 # uvicorn-gunicorn-starlette
 
-[**Docker**](https://www.docker.com/) image with [**Uvicorn**](https://www.uvicorn.org/) managed by [**Gunicorn**](https://gunicorn.org/) for high-performance [**Starlette**](https://www.starlette.io/) web applications in **[Python](https://www.python.org/) 3.7** and **3.6** with performance auto-tuning. Optionally with Alpine Linux.
+[**Docker**](https://www.docker.com/) image with [**Uvicorn**](https://www.uvicorn.org/) managed by [**Gunicorn**](https://gunicorn.org/) for high-performance [**Starlette**](https://www.starlette.io/) web applications in **[Python](https://www.python.org/) 3.8**, **3.7** and **3.6** with performance auto-tuning. Optionally with Alpine Linux.
 
 **GitHub repo**: [https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker)
 

--- a/python3.8-alpine3.10/Dockerfile
+++ b/python3.8-alpine3.10/Dockerfile
@@ -1,0 +1,7 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8-alpine3.10
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+RUN pip install starlette
+
+COPY ./app /app

--- a/python3.8-alpine3.10/app/main.py
+++ b/python3.8-alpine3.10/app/main.py
@@ -1,0 +1,14 @@
+import sys
+
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+
+version = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+app = Starlette()
+
+
+@app.route("/")
+async def homepage(request):
+    message = f"Hello world! From Starlette running on Uvicorn with Gunicorn in Alpine. Using Python {version}"
+    return JSONResponse({"message": message})

--- a/python3.8/Dockerfile
+++ b/python3.8/Dockerfile
@@ -1,0 +1,7 @@
+FROM tiangolo/uvicorn-gunicorn:python3.8
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+RUN pip install starlette
+
+COPY ./app /app

--- a/python3.8/app/main.py
+++ b/python3.8/app/main.py
@@ -1,0 +1,14 @@
+import sys
+
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+
+version = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+app = Starlette()
+
+
+@app.route("/")
+async def homepage(request):
+    message = f"Hello world! From Starlette running on Uvicorn with Gunicorn. Using Python {version}"
+    return JSONResponse({"message": message})

--- a/scripts/process_all.py
+++ b/scripts/process_all.py
@@ -9,6 +9,11 @@ environments = [
         "TEST_STR1": "Hello world! From Starlette running on Uvicorn with Gunicorn. Using Python 3.7",
     },
     {
+        "NAME": "python3.8",
+        "BUILD_PATH": "python3.8",
+        "TEST_STR1": "Hello world! From Starlette running on Uvicorn with Gunicorn. Using Python 3.8",
+    },
+    {
         "NAME": "python3.7",
         "BUILD_PATH": "python3.7",
         "TEST_STR1": "Hello world! From Starlette running on Uvicorn with Gunicorn. Using Python 3.7",
@@ -17,6 +22,11 @@ environments = [
         "NAME": "python3.6",
         "BUILD_PATH": "python3.6",
         "TEST_STR1": "Hello world! From Starlette running on Uvicorn with Gunicorn. Using Python 3.6",
+    },
+    {
+        "NAME": "python3.8-alpine3.10",
+        "BUILD_PATH": "python3.8-alpine3.10",
+        "TEST_STR1": "Hello world! From Starlette running on Uvicorn with Gunicorn in Alpine. Using Python 3.8",
     },
     {
         "NAME": "python3.7-alpine3.8",


### PR DESCRIPTION
Summary:

-   Does NOT modify latest tag
-   Does NOT change previous Dockerfile's Alpine version
-   Provides Python 3.8 containers
-   README still points to 3.7 as example
-   Changes Travis' base `xenial` to `bionic`
-   Should not be merged until `uvloop` compiles in Python 3.8
-   Depends on https://github.com/tiangolo/uvicorn-gunicorn-docker/pull/19

Related https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/pull/18