### PR TITLE
👷 Add support for Python 3.9 and Python 3.9 Alpine

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,15 +11,21 @@ jobs:
       matrix:
         image:
           - name: latest
-            python_version: "3.8"
+            python_version: "3.9"
           - name: python3.8
             python_version: "3.8"
+          - name: python3.9
+            python_version: "3.9"
           - name: python3.7
             python_version: "3.7"
           - name: python3.6
             python_version: "3.6"
+          - name: python3.9-slim
+            python_version: "3.9"
           - name: python3.8-slim
             python_version: "3.8"
+          - name: python3.9-alpine3.14
+            python_version: "3.9"
           - name: python3.8-alpine3.10
             python_version: "3.8"
           - name: python3.7-alpine3.8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,15 +11,21 @@ jobs:
       matrix:
         image:
           - name: latest
-            python_version: "3.8"
+            python_version: "3.9"
+          - name: python3.9
+            python_version: "3.9"
           - name: python3.8
             python_version: "3.8"
           - name: python3.7
             python_version: "3.7"
           - name: python3.6
             python_version: "3.6"
+          - name: python3.9-slim
+            python_version: "3.9"
           - name: python3.8-slim
             python_version: "3.8"
+          - name: python3.9-alpine3.14
+            python_version: "3.9"
           - name: python3.8-alpine3.10
             python_version: "3.8"
           - name: python3.7-alpine3.8

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 ## Supported tags and respective `Dockerfile` links
 
-* [`python3.8`, `latest` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/blob/master/docker-images/python3.8.dockerfile)
+* [`python3.9`, `latest` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/blob/master/docker-images/python3.9.dockerfile)
+* [`python3.8`, _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/blob/master/docker-images/python3.8.dockerfile)
 * [`python3.7`, _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/blob/master/docker-images/python3.7.dockerfile)
 * [`python3.6` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/blob/master/docker-images/python3.6.dockerfile)
-* [`python3.8-slim` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/blob/master/docker-images/python3.8-slim.dockerfile)
-* [`python3.8-alpine3.10` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/blob/master/docker-images/python3.8-alpine3.10.dockerfile)
+* [`python3.8-slim` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/blob/master/docker-images/python3.9-slim.dockerfile)
+* [`python3.9-slim` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/blob/master/docker-images/python3.8-slim.dockerfile)
+* [`python3.8-alpine3.10` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/blob/master/docker-images/python3.9-alpine3.14.dockerfile)
+* [`python3.9-alpine3.14` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/blob/master/docker-images/python3.8-alpine3.10.dockerfile)
 * [`python3.7-alpine3.8` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/blob/master/docker-images/python3.7-alpine3.8.dockerfile)
 * [`python3.6-alpine3.8` _(Dockerfile)_](https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/blob/master/docker-images/python3.6-alpine3.8.dockerfile)
 
@@ -77,7 +80,7 @@ If you are creating a new [**FastAPI**](https://fastapi.tiangolo.com/) web appli
 * You don't need to clone the GitHub repo. You can use this image as a base image for other images, using this in your `Dockerfile`:
 
 ```Dockerfile
-FROM tiangolo/uvicorn-gunicorn-starlette:python3.7
+FROM tiangolo/uvicorn-gunicorn-starlette:python3.9
 
 COPY ./app /app
 ```
@@ -100,7 +103,7 @@ docker build -t myimage ./
 * Create a `Dockerfile` with:
 
 ```Dockerfile
-FROM tiangolo/uvicorn-gunicorn-starlette:python3.7
+FROM tiangolo/uvicorn-gunicorn-starlette:python3.9
 
 COPY ./app /app
 ```
@@ -171,7 +174,7 @@ Let's say you have a project managed with [Poetry](https://python-poetry.org/), 
 Then you could have a `Dockerfile` like:
 
 ```Dockerfile
-FROM tiangolo/uvicorn-gunicorn-starlette:python3.7
+FROM tiangolo/uvicorn-gunicorn-starlette:python3.9
 
 # Install Poetry
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,7 +6,7 @@ use_tag="tiangolo/uvicorn-gunicorn-starlette:$NAME"
 DOCKERFILE="$NAME"
 
 if [ "$NAME" == "latest" ] ; then
-    DOCKERFILE="python3.8"
+    DOCKERFILE="python3.9"
 fi
 
 docker build -t "$use_tag" --file "./docker-images/${DOCKERFILE}.dockerfile" "./docker-images/"

--- a/scripts/process_all.py
+++ b/scripts/process_all.py
@@ -3,11 +3,14 @@ import subprocess
 import sys
 
 environments = [
-    {"NAME": "latest", "PYTHON_VERSION": "3.8"},
+    {"NAME": "latest", "PYTHON_VERSION": "3.9"},
+    {"NAME": "python3.9", "PYTHON_VERSION": "3.9"},
     {"NAME": "python3.8", "PYTHON_VERSION": "3.8"},
     {"NAME": "python3.7", "PYTHON_VERSION": "3.7"},
     {"NAME": "python3.6", "PYTHON_VERSION": "3.6"},
+    {"NAME": "python3.9-slim", "PYTHON_VERSION": "3.9"},
     {"NAME": "python3.8-slim", "PYTHON_VERSION": "3.8"},
+    {"NAME": "python3.9-alpine3.14", "PYTHON_VERSION": "3.9"},
     {"NAME": "python3.8-alpine3.10", "PYTHON_VERSION": "3.8"},
     {"NAME": "python3.7-alpine3.8", "PYTHON_VERSION": "3.7"},
     {"NAME": "python3.6-alpine3.8", "PYTHON_VERSION": "3.6"},


### PR DESCRIPTION
👷 Add support for Python 3.9 and Python 3.9 Alpine.

Actually, I accidentally added the files to support Python 3.9 in https://github.com/tiangolo/uvicorn-gunicorn-starlette-docker/pull/27 some minutes ago. So this PR only enables CI (and deploy) and docs for them.