### PR TITLE
⬆️ Upgrade Uvicorn and Starlette to the latest versions that support Python 3.6

### DIFF
--- a/docker-images/python3.6-alpine3.8.dockerfile
+++ b/docker-images/python3.6-alpine3.8.dockerfile
@@ -2,6 +2,7 @@ FROM tiangolo/uvicorn-gunicorn:python3.6-alpine3.8
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
+RUN pip install --upgrade pip
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 

--- a/docker-images/python3.6.dockerfile
+++ b/docker-images/python3.6.dockerfile
@@ -2,6 +2,7 @@ FROM tiangolo/uvicorn-gunicorn:python3.6
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
+RUN pip install --upgrade pip
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 

--- a/docker-images/requirements.txt
+++ b/docker-images/requirements.txt
@@ -1,3 +1,3 @@
-uvicorn[standard]==0.15.0
+uvicorn[standard]==0.16.0
 gunicorn==20.1.0
-starlette==0.14.2
+starlette==0.19.1


### PR DESCRIPTION
⬆️ Upgrade Uvicorn and Starlette to the latest versions that support Python 3.6