### PR TITLE
👷 Do not run double CI for PRs, run on push only on master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test
 
 on:
   push:
+    branches:
+      - master
   pull_request:
     types: [opened, synchronize]
 


### PR DESCRIPTION
👷 Do not run double CI for PRs, run on push only on master