### PR TITLE
🔒️ Add zizmor workflow security checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,9 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: "tiangolo/uvicorn-gunicorn-starlette:${{ matrix.image.name }}\ntiangolo/uvicorn-gunicorn-starlette:${{ matrix.image.name }}-${{ env.DATE_TAG }} \n"
+          tags: |
+            tiangolo/uvicorn-gunicorn-starlette:${{ matrix.image.name }}
+            tiangolo/uvicorn-gunicorn-starlette:${{ matrix.image.name }}-${{ env.DATE_TAG }} 
           context: ./docker-images/
           file: ./docker-images/${{ env.DOCKERFILE_NAME }}.dockerfile
       - name: Docker Hub Description

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,4 @@
 name: Deploy
-
 on:
   push:
     branches:
@@ -7,7 +6,6 @@ on:
   schedule:
     # cron every week on monday
     - cron: "0 0 * * 1"
-
 jobs:
   deploy:
     strategy:
@@ -26,7 +24,9 @@ jobs:
       fail-fast: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Set Dockerfile name
         if: matrix.image.name != 'latest'
         run: echo "DOCKERFILE_NAME=${{ matrix.image.name }}" >> $GITHUB_ENV
@@ -34,27 +34,28 @@ jobs:
         if: matrix.image.name == 'latest'
         run: echo "DOCKERFILE_NAME=python${{ matrix.image.python_version }}" >> $GITHUB_ENV
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Get date for tags
         run: echo "DATE_TAG=$(date -I)" >> "$GITHUB_ENV"
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: |
-            tiangolo/uvicorn-gunicorn-starlette:${{ matrix.image.name }}
-            tiangolo/uvicorn-gunicorn-starlette:${{ matrix.image.name }}-${{ env.DATE_TAG }} 
+          tags: "tiangolo/uvicorn-gunicorn-starlette:${{ matrix.image.name }}\ntiangolo/uvicorn-gunicorn-starlette:${{ matrix.image.name }}-${{ env.DATE_TAG }} \n"
           context: ./docker-images/
           file: ./docker-images/${{ env.DOCKERFILE_NAME }}.dockerfile
       - name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@v5
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: tiangolo/uvicorn-gunicorn-starlette
+    permissions:
+      contents: read
+permissions: {}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,11 @@ on:
   schedule:
     # cron every week on monday
     - cron: "0 0 * * 1"
+permissions: {}
 jobs:
   deploy:
+    permissions:
+      contents: read
     strategy:
       matrix:
         image:
@@ -56,6 +59,3 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: tiangolo/uvicorn-gunicorn-starlette
-    permissions:
-      contents: read
-permissions: {}

--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -9,7 +9,7 @@ on:
   issues:
     types:
       - labeled
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types:
       - labeled
   workflow_dispatch:
@@ -22,7 +22,7 @@ jobs:
   issue-manager:
     runs-on: ubuntu-latest
     steps:
-      - uses: tiangolo/issue-manager@0.6.0
+      - uses: tiangolo/issue-manager@2fb3484ec9279485df8659e8ec73de262431737d # 0.6.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config: >

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -21,10 +21,10 @@ jobs:
     - run: echo "Done adding labels"
   # Run this after labeler applied labels
   check-labels:
-    needs:
-      - labeler
     permissions:
       pull-requests: read
+    needs:
+      - labeler
     runs-on: ubuntu-latest
     steps:
       - uses: docker://agilepathway/pull-request-label-checker:latest

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: Labels
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types:
       - opened
       - synchronize
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v6
+    - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
       if: ${{ github.event.action != 'labeled' && github.event.action != 'unlabeled' }}
     - run: echo "Done adding labels"
   # Run this after labeler applied labels

--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -23,8 +23,8 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          token: ${{ secrets.UVICORN_GUNICORN_STARLETTE_DOCKER_LATEST_CHANGES }}
-          persist-credentials: false
+          token: ${{ secrets.UVICORN_GUNICORN_STARLETTE_DOCKER_LATEST_CHANGES }} # zizmor: ignore[secrets-outside-env]
+          persist-credentials: true # required by tiangolo/latest-changes
       - uses: tiangolo/latest-changes@eb3f6e7ff0073896ecb561e774a121de9418fa06 # 0.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -16,6 +16,9 @@ on:
         default: 'false'
 jobs:
   latest-changes:
+    permissions:
+      contents: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -25,6 +28,3 @@ jobs:
       - uses: tiangolo/latest-changes@eb3f6e7ff0073896ecb561e774a121de9418fa06 # 0.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      contents: write
-      pull-requests: read

--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -1,7 +1,6 @@
 name: Latest Changes
-
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     branches:
       - master
     types:
@@ -15,14 +14,17 @@ on:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: 'false'
-
 jobs:
   latest-changes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           token: ${{ secrets.UVICORN_GUNICORN_STARLETTE_DOCKER_LATEST_CHANGES }}
-      - uses: tiangolo/latest-changes@0.5.0
+          persist-credentials: false
+      - uses: tiangolo/latest-changes@eb3f6e7ff0073896ecb561e774a121de9418fa06 # 0.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+      pull-requests: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,11 @@ on:
   schedule:
     # cron every week on monday
     - cron: "0 0 * * 1"
+permissions: {}
 jobs:
   test:
+    permissions:
+      contents: read
     strategy:
       matrix:
         image:
@@ -55,9 +58,8 @@ jobs:
         env:
           NAME: ${{ matrix.image.name }}
           PYTHON_VERSION: ${{ matrix.image.python_version }}
-    permissions:
-      contents: read
   check:
+    permissions: {}
     if: always()
     needs:
       - test
@@ -67,5 +69,3 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-    permissions: {}
-permissions: {}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,4 @@
 name: Test
-
 on:
   push:
     branches:
@@ -11,7 +10,6 @@ on:
   schedule:
     # cron every week on monday
     - cron: "0 0 * * 1"
-
 jobs:
   test:
     strategy:
@@ -30,7 +28,9 @@ jobs:
       fail-fast: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Set Dockerfile name
         if: matrix.image.name != 'latest'
         run: echo "DOCKERFILE_NAME=${{ matrix.image.name }}" >> $GITHUB_ENV
@@ -38,14 +38,14 @@ jobs:
         if: matrix.image.name == 'latest'
         run: echo "DOCKERFILE_NAME=python${{ matrix.image.python_version }}" >> $GITHUB_ENV
       - name: Build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           push: false
           tags: tiangolo/uvicorn-gunicorn-starlette:${{ matrix.image.name }}
           context: ./docker-images/
           file: ./docker-images/${{ env.DOCKERFILE_NAME }}.dockerfile
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.10"
       - name: Install Dependencies
@@ -55,13 +55,17 @@ jobs:
         env:
           NAME: ${{ matrix.image.name }}
           PYTHON_VERSION: ${{ matrix.image.python_version }}
+    permissions:
+      contents: read
   check:
     if: always()
     needs:
-    - test
+      - test
     runs-on: ubuntu-latest
     steps:
-    - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@release/v1
-      with:
-        jobs: ${{ toJSON(needs) }}
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}
+    permissions: {}
+permissions: {}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,6 @@ jobs:
           NAME: ${{ matrix.image.name }}
           PYTHON_VERSION: ${{ matrix.image.python_version }}
   check:
-    permissions: {}
     if: always()
     needs:
       - test

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -8,14 +8,14 @@ on:
     branches:
       - master
 
-permissions: {}
 
+permissions: {}
 jobs:
   zizmor:
-    runs-on: ubuntu-latest
     permissions:
       security-events: write
       contents: read
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: zizmor
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
-
-
 permissions: {}
 jobs:
   zizmor:


### PR DESCRIPTION
## Changes

- Add a GitHub Actions workflow to audit workflow security with zizmor.
- Run zizmor in online fix mode so action references are pinned by zizmor.

## AI Disclaimer

Codex GPT 5.5, reviewed by hand.
